### PR TITLE
Fixed url in dmidecode.rb

### DIFF
--- a/Formula/dmidecode.rb
+++ b/Formula/dmidecode.rb
@@ -1,7 +1,7 @@
 class Dmidecode < Formula
   desc "Dmidecode reports information about your system's hardware."
   homepage "https://github.com/cavaliercoder/dmidecode-osx"
-  url "https://github.com/cavaliercoder/dmidecode-osx/archive/v3.1.tar.gz"
+  url "https://github.com/cavaliercoder/dmidecode-osx/archive/refs/tags/v3.1.tar.gz"
   version "3.1"
   sha256 "b7ee6fe84e0e9015ac09a903fc3906c388087da504e394e07cb2cd274ba3faa1"
 


### PR DESCRIPTION
Old version downloads wrong file because in returns a github webpage with error "the given path has multiple possibilities: #<Git::Ref:0x00007f46b4cdc1c8>, #<Git::Ref:0x00007f46b4cdb5e8>"